### PR TITLE
Support building osx binaries on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,16 @@ language: go
 go:
 - 1.14.x
 script:
-  - go get -v -d ./... 
-  - go build
+  - go get -v -d ./...
+  - GOOS=linux GOARCH=amd64 go build -o untrak-linux
+  - GOOS=darwin GOARCH=amd64 go build -o untrak-darwin
 deploy:
   provider: releases
   api_key:
     secure: u76RGeXFqXOBTOiEFChuXS7C1aaLl7vX8J39hOyla22LAyIeSOmOK6atwMfz6zq3cui9wo/bQ6Mke3p5Fzm1bhvA1srLo+Ma59JYEzsMvyDE0A7OZG7W8S+iJYEn/rlLGBzjAozg0TlmOMh8s/H05TyUEVOOqFwlEyb/O4H4Zg/ooJdNv0A+MLYGqgCiyyDv2tuMzY6GNeiBLrR69iAJfEjkrOfzC+dnVKEHi9K6OV1UEWX/63VHd2SfvJmG9vOL++3QH05ToMP0Geuek0fvQ0c5EYjAZYW4d4zw3dxXsHLwN7GRjQuos0uGXGqeHaSkYfSbtDQhLNV3FRjXlp8r4fhjhHcWQm4GO5tZItMMWVFwA8S1v+aiZ4B2NwrewwOxRzyBqtYGV16yklkHngOwsbU3596TKQeWv9v7sCw7f1N+uoAYmbyf7Si95WZnvkdIW1DvADg/32+dOcsLOKWFo1wlkoA44O8qOUetfHFd9DDApvd1n6XfvsWkejOdk8X02R/1XB3fCFRxONegIsVXjhlodBS0AzoF398goDfiDtj9TCdOwHUMIGFGZ/SARJRFwkCNkzY46B1/P4yH/vzrxIsALAuPDGUjqfrERtpl289M/0SNz4j7hhDgVYq+BLzipErDMmT+3l+RRTR9rKcHWN2NNm2zkDNoNRVvyiZtpp0=
-  file: untrak
+  file:
+    - untrak-linux
+    - untrak-darwin
   skip_cleanup: true
   on:
     tags: true

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ $ untrak -c untrak.yaml -o text
 - api/Ingress/my-ingress
 ```
 
+If your manifests have the namespace set to non-namespaced resource, untrak will skip the namespace. A list of supported non-namespaced resource types that will be skipped are defined by default. If you have installed more non-namespaced resource types (eg., `CRDs`), you could add extra resource types to skip namespace in comparison:
+```yaml
+# untrak.yaml
+## git sources
+in:
+...
+
+## cluster manifests
+out:
+...
+
+nonNamespaced:
+- some_crd_type
+```
+
 If you need to garbage collect them, you can change the output format to yaml and pipe the result in kubectl:
 
 ```
@@ -63,4 +78,11 @@ configmap "django-config-b4k42gm792" deleted
 configmap "django-config-g55mctg456" deleted
 ingress.extensions "my-ingress" deleted
 ```
+
+If you want to fail on untracked resources (exit status 1), you can use `-fail=true`:
+
+```
+$ untrak -c untrak.yaml -fail=true
+```
+
 > **Caution**: please test this tool extensively before deleting resources. The software is provided "as is", without warranty of any kind.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ nonNamespaced:
 - some_crd_type
 ```
 
+You can use environment variables on command arguments (in/out):
+```yaml
+in:
+- cmd: "cat"
+  args: ["example/$SOME_FILE_NAME"]
+...
+```
+
 If you need to garbage collect them, you can change the output format to yaml and pipe the result in kubectl:
 
 ```

--- a/config/structs.go
+++ b/config/structs.go
@@ -6,7 +6,8 @@ type CommandConfig struct {
 }
 
 type Config struct {
-	In     []*CommandConfig `yaml:"in"`
-	Out    []*CommandConfig `yaml:"out"`
-	Exclude []string         `yaml:"exclude"`
+	In            []*CommandConfig `yaml:"in"`
+	Out           []*CommandConfig `yaml:"out"`
+	Exclude       []string         `yaml:"exclude"`
+	NonNamespaced []string         `yaml:"nonNamespaced"`
 }

--- a/kubernetes/non_namespaced.go
+++ b/kubernetes/non_namespaced.go
@@ -1,0 +1,22 @@
+package kubernetes
+
+var DefaultNonNamespacedResources = []string{
+	"componentstatuse",
+	"namespace",
+	"node",
+	"persistentvolume",
+	"mutatingwebhookconfiguration",
+	"validatingwebhookconfiguration",
+	"customresourcedefinition",
+	"apiservice",
+	"certificatesigningrequest",
+	"runtimeclass",
+	"podsecuritypolicy",
+	"clusterrolebinding",
+	"clusterrole",
+	"priorityclass",
+	"csidriver",
+	"csinode",
+	"storageclass",
+	"volumeattachment",
+}

--- a/main.go
+++ b/main.go
@@ -18,27 +18,6 @@ import (
 	"github.com/yanc0/untrak/config"
 )
 
-var defaultNonNamespacedResources = []string{
-	"componentstatuse",
-	"namespace",
-	"node",
-	"persistentvolume",
-	"mutatingwebhookconfiguration",
-	"validatingwebhookconfiguration",
-	"customresourcedefinition",
-	"apiservice",
-	"certificatesigningrequest",
-	"runtimeclass",
-	"podsecuritypolicy",
-	"clusterrolebinding",
-	"clusterrole",
-	"priorityclass",
-	"csidriver",
-	"csinode",
-	"storageclass",
-	"volumeattachment",
-}
-
 func main() {
 	// Flags, command line parameters
 	var cfgPathOpt = flag.String("config", "./untrak.yaml", "untrak Config Path")
@@ -57,7 +36,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	cfg.NonNamespaced = append(cfg.NonNamespaced, defaultNonNamespacedResources...)
+	cfg.NonNamespaced = append(cfg.NonNamespaced, kubernetes.DefaultNonNamespacedResources...)
 
 	wg.Add(1)
 	go func() {

--- a/main.go
+++ b/main.go
@@ -18,6 +18,27 @@ import (
 	"github.com/yanc0/untrak/config"
 )
 
+var defaultNonNamespacedResources = []string{
+	"componentstatuse",
+	"namespace",
+	"node",
+	"persistentvolume",
+	"mutatingwebhookconfiguration",
+	"validatingwebhookconfiguration",
+	"customresourcedefinition",
+	"apiservice",
+	"certificatesigningrequest",
+	"runtimeclass",
+	"podsecuritypolicy",
+	"clusterrolebinding",
+	"clusterrole",
+	"priorityclass",
+	"csidriver",
+	"csinode",
+	"storageclass",
+	"volumeattachment",
+}
+
 func main() {
 	// Flags, command line parameters
 	var cfgPathOpt = flag.String("config", "./untrak.yaml", "untrak Config Path")
@@ -35,6 +56,8 @@ func main() {
 		log.Printf("[ERR] Cannot load %s file: %v\n", *cfgPathOpt, err)
 		os.Exit(1)
 	}
+
+	cfg.NonNamespaced = append(cfg.NonNamespaced, defaultNonNamespacedResources...)
 
 	wg.Add(1)
 	go func() {

--- a/main.go
+++ b/main.go
@@ -107,6 +107,12 @@ func getKubernetesResources(cfgs []*config.CommandConfig) ([]*kubernetes.Resourc
 		wg.Add(1)
 		go func(cmd string, args ...string) {
 			defer wg.Done()
+
+			// substitute env variables if any has been set
+			for i, _ := range args {
+				args[i] = os.ExpandEnv(args[i])
+			}
+
 			c := exec.Command(cmd, args...)
 			var outb, errb bytes.Buffer
 			c.Stdout = &outb

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 	// Flags, command line parameters
 	var cfgPathOpt = flag.String("config", "./untrak.yaml", "untrak Config Path")
 	var outputOpt = flag.String("o", "text", "Output format")
+	var failOpt = flag.Bool("fail", false, "Fail on untracked resources")
 	flag.Parse()
 
 	var wg sync.WaitGroup
@@ -65,6 +66,10 @@ func main() {
 		outputs.YAML(untrackedResources)
 	default:
 		outputs.Text(untrackedResources)
+	}
+
+	if len(untrackedResources) > 0 && *failOpt {
+		os.Exit(1)
 	}
 }
 

--- a/untrak.yaml
+++ b/untrak.yaml
@@ -24,3 +24,9 @@ exclude:
 - namespace
 - secret
 - configmap
+
+# Declare non-namespaced resource types to be considered in resource comparison.
+# There are some defined resource types by default by default like namespace,
+# node, clusterrole, etc.
+# nonNamespaced:
+# - some_crd_type

--- a/untrak.yaml
+++ b/untrak.yaml
@@ -19,6 +19,11 @@ out:
 # - cmd: "kubectl"
 #   args: ["get", "cm,deploy,svc,ing", "-o", "yaml", "-n", "api"]
 
+# You can use environment variables on command args
+# out:
+# - cmd: "cat"
+#   args: ["example/$SOME_FILE_NAME"]
+
 # You can exclude some resource type from the comparison
 exclude:
 - namespace


### PR DESCRIPTION
Hello,

This PR will add support:
* Building OSX binaries
* If user passed input manifest that set the namespace on non-namespaced resources and kubectl is used to get the output, this resource will be treated as untracked. Adding support to `nonNamespaced` will allow user to pre-set the types of resources that are non-namespaced (eg, non-namespaced CRDs). Further a list of the latest non-namespaced resource types is provided by deafult.
* Support failure on untracked resources is very useful for CI/CD pipelines 