### PR TITLE
Replace resource kind exclusion with resource ID and supporting regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ out:
   args: ["get", "cm,deploy,svc,ing", "-o", "yaml", "-n", "api"]
 
 exclude:
-- namespace
+- /namespace/.*
 ```
 To show untracked resources in your cluster (out) simply launch `untrak` like so:
 
@@ -54,6 +54,15 @@ $ untrak -c untrak.yaml -o text
 - api/ConfigMap/django-config-g55mctg456
 - api/Ingress/my-ingress
 ```
+
+The untracked resources have the following format:
+* *Namespaced resources*: `namespace/kind/name`
+* *Non-namespaced resources*: `/kind/name`
+
+You can exclude any resource (with the previous format) form tracking by setting `exclude` section in the config file with list of excluded resources. The excluded resource could be a full resource name or regular expressions. For examples:
+* to exclude any namespace resource: `/namespace/.*`
+* to exclude secret `sec` in namespace `deafult`: `deafult/secret/sec`
+* to exclude any config map: `.*/configmap/.*`
 
 If your manifests have the namespace set to non-namespaced resource, untrak will skip the namespace. A list of supported non-namespaced resource types that will be skipped are defined by default. If you have installed more non-namespaced resource types (eg., `CRDs`), you could add extra resource types to skip namespace in comparison:
 ```yaml

--- a/untrak.yaml
+++ b/untrak.yaml
@@ -24,11 +24,11 @@ out:
 # - cmd: "cat"
 #   args: ["example/$SOME_FILE_NAME"]
 
-# You can exclude some resource type from the comparison
+# You can exclude some resource from the comparison using resource name or regular expression
 exclude:
-- namespace
-- secret
-- configmap
+- /namespace/.*
+- deafult/secret/sec
+- .*/configmap/.*
 
 # Declare non-namespaced resource types to be considered in resource comparison.
 # There are some defined resource types by default by default like namespace,

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -2,12 +2,23 @@ package utils
 
 import (
 	"strings"
+	"regexp"
 )
 
 // StringInListCaseInsensitive return true if str is in the list (case insensitive)
 func StringInListCaseInsensitive(list []string, str string) bool {
 	for _, s := range list {
 		if strings.ToLower(s) == strings.ToLower(str) {
+			return true
+		}
+	}
+	return false
+}
+
+// StringListRegexpMatch return true if str is matching any of the regexp in the list
+func StringListRegexpMatch(list []*regexp.Regexp, str string) bool {
+	for _, r := range list {
+		if r.MatchString(strings.ToLower(str)) {
 			return true
 		}
 	}


### PR DESCRIPTION
This PR will replace the mechanism of `exclude`. The current behaviour is to exclude only resource kind. For more flexibility and control of what could be excluded, the behaviour has been changed in this PR to support resource ID (`namespace/kind/name` or `/kind/name`). Further you can use resource full name or regular expression.

 Examples:
* to exclude any namespace resource: `/namespace/.*`
* to exclude secret `sec` in namespace `deafult`: `deafult/secret/sec`
* to exclude any config map: `.*/configmap/.*`